### PR TITLE
Green skill classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 - Run `make install` to configure the development environment:
   - Setup the conda environment
   - Configure `pre-commit`
-- run `python -m spacy download en_core_web_sm`
 
 ## Contributor guidelines
 

--- a/dap_prinz_green_jobs/config/base.yaml
+++ b/dap_prinz_green_jobs/config/base.yaml
@@ -20,7 +20,7 @@ skills:
   skills_output: "outputs/data/green_skill_lists/20230914/skills_data_ojo_mixed.json" # Set if load_skills is True
   skill_embeddings_output: "outputs/data/green_skill_lists/20230914/extracted_skills_embeddings.json" # Set if load_skills_embeddings is True
   green_tax_embedding_path: "outputs/data/green_skill_lists/green_esco_embeddings_20230815.json" # Set if load_taxonomy_embeddings is True
-  green_skills_classifier_model_file: "outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib"
+  green_skills_classifier_model_file_name: "outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib"
 occupations:
   local: False
   embeddings_output_dir: "outputs/data/green_occupations/soc_matching/"

--- a/dap_prinz_green_jobs/config/base.yaml
+++ b/dap_prinz_green_jobs/config/base.yaml
@@ -17,8 +17,8 @@ skills:
   load_skills: False # If False it doesn't matter what skills_output is
   load_skills_embeddings: False # If False it doesn't matter what skill_embeddings_output is
   load_taxonomy_embeddings: True # If False it doesn't matter what green_tax_embedding_path is
-  skills_output: "outputs/data/green_skill_lists/skills_data_ojo_mixed_20230815.json" # Set if load_skills is True
-  skill_embeddings_output: "outputs/data/green_skill_lists/extracted_skills_embeddings_20230816.json" # Set if load_skills_embeddings is True
+  skills_output: "outputs/data/green_skill_lists/20230914/skills_data_ojo_mixed.json" # Set if load_skills is True
+  skill_embeddings_output: "outputs/data/green_skill_lists/20230914/extracted_skills_embeddings.json" # Set if load_skills_embeddings is True
   green_tax_embedding_path: "outputs/data/green_skill_lists/green_esco_embeddings_20230815.json" # Set if load_taxonomy_embeddings is True
   green_skills_classifier_model_file: "outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib"
 occupations:

--- a/dap_prinz_green_jobs/config/base.yaml
+++ b/dap_prinz_green_jobs/config/base.yaml
@@ -14,12 +14,13 @@ job_adverts:
   company_name_key: "company_name"
 skills:
   skills_config_name: "extract_green_skills_esco"
-  load_skills: True
-  load_skills_embeddings: True
-  load_taxonomy_embeddings: True
-  skills_output: "outputs/data/green_skill_lists/skills_data_ojo_mixed_20230815.json"
-  skill_embeddings_output: "outputs/data/green_skill_lists/extracted_skills_embeddings_20230816.json"
-  green_tax_embedding_path: "outputs/data/green_skill_lists/green_esco_embeddings_20230815.json"
+  load_skills: False # If False it doesn't matter what skills_output is
+  load_skills_embeddings: False # If False it doesn't matter what skill_embeddings_output is
+  load_taxonomy_embeddings: True # If False it doesn't matter what green_tax_embedding_path is
+  skills_output: "outputs/data/green_skill_lists/skills_data_ojo_mixed_20230815.json" # Set if load_skills is True
+  skill_embeddings_output: "outputs/data/green_skill_lists/extracted_skills_embeddings_20230816.json" # Set if load_skills_embeddings is True
+  green_tax_embedding_path: "outputs/data/green_skill_lists/green_esco_embeddings_20230815.json" # Set if load_taxonomy_embeddings is True
+  green_skills_classifier_model_file: "outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib"
 occupations:
   local: False
   embeddings_output_dir: "outputs/data/green_occupations/soc_matching/"

--- a/dap_prinz_green_jobs/pipeline/green_measures/green_measures.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/green_measures.py
@@ -117,51 +117,21 @@ class GreenMeasures(object):
         if type(job_advert) == dict:
             job_advert = [job_advert]
 
-        predicted_entities = self.sm.get_entities(
-            job_advert,
-            output_path=self.skills_output,
-            load=self.load_skills,
-            job_text_key=self.job_text_key,
-            job_id_key=self.job_id_key,
-        )
-
-        ents_per_job = {}
-        job_benefits_dict = defaultdict(list)
-        for job_id, p in predicted_entities.items():
-            job_ents = []
-            for ent_type in ["SKILL", "MULTISKILL", "EXPERIENCE"]:
-                for skill in p[ent_type]:
-                    split_ent_list = split_up_skill_entities(skill)
-                    job_ents.append((split_ent_list, ent_type))
-            ents_per_job[job_id] = job_ents
-            for benefit in p["BENEFIT"]:
-                job_benefits_dict[str(job_id)].append(benefit)
-
-        # Unique list of skills
-        unique_skills_list = list(
-            set([g for v in ents_per_job.values() for r in v for g in r[0]])
-        )
-
-        all_extracted_skills_embeddings_dict = self.sm.get_skill_embeddings(
-            unique_skills_list,
-            output_path=self.skill_embeddings_output,
-            load=self.load_skills_embeddings,
-        )
-
         taxonomy_skills_embeddings_dict = self.sm.get_green_taxonomy_embeddings(
             output_path=self.green_tax_embedding_path,
             load=self.load_taxonomy_embeddings,
         )
 
-        all_extracted_green_skills_dict = self.sm.map_green_skills(
-            unique_skills_list, all_extracted_skills_embeddings_dict
+        prop_green_skills = self.sm.get_measures(
+            job_advert,
+            skills_output_path=self.skills_output,
+            load_skills=self.load_skills,
+            job_text_key=self.job_text_key,
+            job_id_key=self.job_id_key,
+            skill_embeddings_output_path=self.skill_embeddings_output,
+            load_skills_embeddings=self.load_skills_embeddings,
         )
 
-        prop_green_skills = self.sm.get_measures(
-            ents_per_job=ents_per_job,
-            all_extracted_green_skills_dict=all_extracted_green_skills_dict,
-            job_benefits_dict=job_benefits_dict,
-        )
         return prop_green_skills
 
     def get_occupation_measures(self, job_advert: Dict[str, str]) -> List[dict]:

--- a/dap_prinz_green_jobs/pipeline/green_measures/green_measures.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/green_measures.py
@@ -27,6 +27,8 @@ class GreenMeasures(object):
     Attributes
     ----------
     config_name (str): the name of the config file to use.
+    skills_output_folder (str): If given, this will be the folder where all skills outputs are stored,
+        if not given it will default to f"outputs/data/green_skill_lists/{date_stamp}"
     ----------
     Methods
     ----------
@@ -42,10 +44,7 @@ class GreenMeasures(object):
             you can also pass a skill list to avoid re-extracting skills.
     """
 
-    def __init__(
-        self,
-        config_name: str = "base",
-    ):
+    def __init__(self, config_name: str = "base", skills_output_folder: str = ""):
         # Set variables from the config file
         if ".yaml" not in config_name:
             config_name += ".yaml"
@@ -71,9 +70,10 @@ class GreenMeasures(object):
             "green_skills_classifier_model_file"
         ]
 
-        date_stamp = str(date.today().date()).replace("-", "")
+        if not skills_output_folder:
+            date_stamp = str(date.today().date()).replace("-", "")
+            skills_output_folder = f"outputs/data/green_skill_lists/{date_stamp}"
 
-        skills_output_folder = f"outputs/data/green_skill_lists/{date_stamp}"
         if self.load_skills:
             self.skills_output = self.config["skills"]["skills_output"]
         else:
@@ -98,6 +98,11 @@ class GreenMeasures(object):
             self.green_tax_embedding_path = os.path.join(
                 skills_output_folder, "green_esco_embeddings.json"
             )
+
+        # Where to output the mappings of skills to all of ESCO (not just green)
+        self.skill_mappings_output_path = os.path.join(
+            skills_output_folder, "full_esco_skill_mappings.json"
+        )
 
         # Input job advert data config variables
         self.job_id_key = self.config["job_adverts"]["job_id_key"]
@@ -140,6 +145,7 @@ class GreenMeasures(object):
             job_id_key=self.job_id_key,
             skill_embeddings_output_path=self.skill_embeddings_output,
             load_skills_embeddings=self.load_skills_embeddings,
+            skill_mappings_output_path=self.skill_mappings_output_path,
         )
 
         return prop_green_skills

--- a/dap_prinz_green_jobs/pipeline/green_measures/green_measures.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/green_measures.py
@@ -11,16 +11,13 @@ from dap_prinz_green_jobs.pipeline.green_measures.industries.industries_measures
 )
 from dap_prinz_green_jobs.pipeline.green_measures.skills.skill_measures_utils import (
     SkillMeasures,
-    split_up_skill_entities,
 )
 from dap_prinz_green_jobs import logger, PROJECT_DIR
 
 from typing import List, Union, Dict, Optional
-from uuid import uuid4
 import yaml
 import os
 from datetime import datetime as date
-from collections import defaultdict
 
 
 class GreenMeasures(object):

--- a/dap_prinz_green_jobs/pipeline/green_measures/green_measures.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/green_measures.py
@@ -67,27 +67,37 @@ class GreenMeasures(object):
         self.load_taxonomy_embeddings = self.config["skills"][
             "load_taxonomy_embeddings"
         ]  # Set to false if your input taxonomy data or way to embed changes
+        self.green_skills_classifier_model_file = self.config["skills"][
+            "green_skills_classifier_model_file"
+        ]
 
         date_stamp = str(date.today().date()).replace("-", "")
 
+        skills_output_folder = f"outputs/data/green_skill_lists/{date_stamp}"
         if self.load_skills:
             self.skills_output = self.config["skills"]["skills_output"]
         else:
-            self.skills_output = f"outputs/data/green_skill_lists/skills_data_ojo_mixed_{date_stamp}.json"
+            self.skills_output = os.path.join(
+                skills_output_folder, "skills_data_ojo_mixed.json"
+            )
 
         if self.load_skills_embeddings:
             self.skill_embeddings_output = self.config["skills"][
                 "skill_embeddings_output"
             ]
         else:
-            self.skill_embeddings_output = f"outputs/data/green_skill_lists/extracted_skills_embeddings_{date_stamp}.json"
+            self.skill_embeddings_output = os.path.join(
+                skills_output_folder, "extracted_skills_embeddings.json"
+            )
 
         if self.load_taxonomy_embeddings:
             self.green_tax_embedding_path = self.config["skills"][
                 "green_tax_embedding_path"
             ]
         else:
-            self.green_tax_embedding_path = f"outputs/data/green_skill_lists/green_esco_embeddings_{date_stamp}.json"
+            self.green_tax_embedding_path = os.path.join(
+                skills_output_folder, "green_esco_embeddings.json"
+            )
 
         # Input job advert data config variables
         self.job_id_key = self.config["job_adverts"]["job_id_key"]
@@ -104,7 +114,10 @@ class GreenMeasures(object):
         self.im.load_ch()
 
         # Skills attributes
-        self.sm = SkillMeasures(config_name="extract_green_skills_esco")
+        self.sm = SkillMeasures(
+            config_name="extract_green_skills_esco",
+            green_skills_classifier_model_file=self.green_skills_classifier_model_file,
+        )
         self.sm.initiate_extract_skills(local=False, verbose=True)
 
     def get_skill_measures(

--- a/dap_prinz_green_jobs/pipeline/green_measures/green_measures.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/green_measures.py
@@ -66,8 +66,8 @@ class GreenMeasures(object):
         self.load_taxonomy_embeddings = self.config["skills"][
             "load_taxonomy_embeddings"
         ]  # Set to false if your input taxonomy data or way to embed changes
-        self.green_skills_classifier_model_file = self.config["skills"][
-            "green_skills_classifier_model_file"
+        self.green_skills_classifier_model_file_name = self.config["skills"][
+            "green_skills_classifier_model_file_name"
         ]
 
         if not skills_output_folder:
@@ -121,7 +121,7 @@ class GreenMeasures(object):
         # Skills attributes
         self.sm = SkillMeasures(
             config_name="extract_green_skills_esco",
-            green_skills_classifier_model_file=self.green_skills_classifier_model_file,
+            green_skills_classifier_model_file_name=self.green_skills_classifier_model_file_name,
         )
         self.sm.initiate_extract_skills(local=False, verbose=True)
 

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/README.md
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/README.md
@@ -97,6 +97,10 @@ As you can see, the closest green ESCO skill will always be outputted, even if t
 Note: predicting skill entities and embedding them for comparison with the green skills taxonomy can take a long time if you are inputting many job adverts.
 
 ```python
+
+from dap_prinz_green_jobs.pipeline.green_measures.skills.skill_measures_utils import (
+    SkillMeasures,
+)
 sm = SkillMeasures(config_name="extract_green_skills_esco")
 sm.initiate_extract_skills(local=False, verbose=True)
 

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/README.md
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/README.md
@@ -30,6 +30,54 @@ To add the custom config file, formatted skills taxonomy and taxonomy embeddings
 python dap_prinz_green_jobs/pipeline/green_measures/skills/customise_skills_extractor.py --config_name "extract_green_skills_esco"
 ```
 
+### Green skills classifier
+
+To train the green skills random forest classifier run:
+
+```
+python dap_prinz_green_jobs/pipeline/green_measures/skills/green_skill_classifier.py
+
+```
+
+The training data for this is `s3://prinz-green-jobs/inputs/data/training_data/green_skill_training_data.csv` - this was created by labelling a dataset of frequently occurring skills, as well as skills which are mapped to ESCO green skills with a high similarity score.
+
+This dataset contains 971 skills labelled as not-green and 743 labelled as green.
+
+The most recently saved model `s3://prinz-green-jobs/outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib` has the following test metrics:
+
+```
+              precision    recall  f1-score   support
+
+       green       0.90      0.86      0.88       175
+   not_green       0.91      0.94      0.92       254
+
+    accuracy                           0.91       429
+   macro avg       0.91      0.90      0.90       429
+weighted avg       0.91      0.91      0.91       429
+
+```
+
+This trained model can be loaded and used by running:
+
+```python
+from dap_prinz_green_jobs.pipeline.green_measures.skills.green_skill_classifier import GreenSkillClassifier
+
+green_skills_classifier = GreenSkillClassifier()
+green_skills_classifier.load_esco_data()
+green_skills_classifier.load(
+    model_file="s3://prinz-green-jobs/outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib"
+)
+
+pred_green_skill = green_skills_classifier.predict(
+    ["Excel skills", "Heat pump installation skills"]
+)
+
+>>> [('not_green', 1.0, ('carry out sample analysis', '82423b5c-486f-42e7-b00e-7358757a8de5', 0.2772792296638087)), ('green', 0.7191159533073931, ('heat pump installation', '00735755-adc6-4ea0-b034-b8caff339c9f', 0.9072619656040537))]
+
+```
+
+As you can see, the closest green ESCO skill will always be outputted, even if the skill have been predicted as "not_green".
+
 ## Datasets used
 
 - `greenSkillsCollection_en.csv`: A dataset of ESCO's green skills as downloaded on the 24th April 2023. This is stored on S3 [here](`s3://prinz-green-jobs/inputs/data/green_skill_lists/esco/greenSkillsCollection_en.csv`).

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/green_esco_formatting.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/green_esco_formatting.py
@@ -31,11 +31,9 @@ if __name__ == "__main__":
         "escoe_extension/outputs/data/skill_ner_mapping/esco_data_formatted.csv",
     )
 
-    formatted_green_esco_skills = (
-        formatted_esco_skills[formatted_esco_skills["id"].isin(esco_green_skills["id"])]
-        .reset_index(drop=True)
-        .set_index("id")
-    )
+    formatted_green_esco_skills = formatted_esco_skills[
+        formatted_esco_skills["id"].isin(esco_green_skills["id"])
+    ].reset_index(drop=True)
 
     logger.info("uploading formatted esco green skills taxonomy")
     save_to_s3(

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/green_skill_classifier.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/green_skill_classifier.py
@@ -16,22 +16,22 @@ import spacy
 from dap_prinz_green_jobs.utils.bert_vectorizer import get_embeddings
 from dap_prinz_green_jobs.getters.data_getters import load_s3_data, save_to_s3
 from dap_prinz_green_jobs.getters.skill_getters import get_green_skills_taxonomy
-from dap_prinz_green_jobs import BUCKET_NAME, logger
+from dap_prinz_green_jobs import BUCKET_NAME, OJO_BUCKET_NAME, logger
 from dap_prinz_green_jobs.getters.occupation_getters import (
     load_onet_green_topics,
 )
 
 from tqdm import tqdm
-from typing import List, Union, Tuple
+from typing import List, Union, Tuple, Dict, Any
 import joblib
 import s3fs
 from datetime import datetime
 import os
 
-OJO_BUCKET_NAME = "open-jobs-lake"
 
-
-def find_green_topics(skill_ent: str, green_topics: list) -> list:
+def find_green_topics(
+    skill_ent: str, green_topics: List[str]
+) -> Union[List[str], List[None]]:
     """
     Find the green topics which are contained within a skill entity using exact matching
     Args:
@@ -54,7 +54,7 @@ def find_green_topics(skill_ent: str, green_topics: list) -> list:
     return found_green_topics
 
 
-def process_green_topic_data(nlp):
+def process_green_topic_data(nlp) -> List[str]:
     """
     Function to load the ONET green topic data, clean it, add to it
 
@@ -117,9 +117,9 @@ def process_green_topic_data(nlp):
 
 
 def get_closest_match(
-    skills_list_embeddings_dict: dict,
-    green_data_embeddings_dict: dict,
-    formatted_green_data: pd.DataFrame(),
+    skills_list_embeddings_dict: Dict[str, np.ndarray],
+    green_data_embeddings_dict: Dict[Any, np.ndarray],
+    formatted_green_data: pd.DataFrame,
 ) -> dict:
     """
     Find the semantically closest matches for each skill in skills_list_embeddings_dict
@@ -154,7 +154,7 @@ def get_closest_match(
 def get_green_skill_matches(
     extracted_skill_list: List[str],
     similarities: np.array,
-    green_skills_taxonomy: pd.DataFrame(),
+    green_skills_taxonomy: pd.DataFrame,
     skill_threshold: float = 0.7,
 ) -> List[Tuple[str, Tuple[str, int]]]:
     """Get green skill matches for a list of extracted skills - use this

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/green_skill_classifier.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/green_skill_classifier.py
@@ -241,7 +241,7 @@ class GreenSkillClassifier(object):
     def transform(
         self,
         skill_entity_list: Union[str, List[str]],
-        skills_list_embeddings_dict: Union[None, list],
+        skills_list_embeddings_dict: Union[None, list] = None,
     ):
         """
         Transform a list of skill entities into 3 numerical features;
@@ -332,7 +332,7 @@ class GreenSkillClassifier(object):
     def predict(
         self,
         skill_entity_list: Union[str, List[str]],
-        skills_list_embeddings_dict: Union[None, list],
+        skills_list_embeddings_dict: Union[None, list] = None,
         output_match: bool = True,
     ) -> list:
         """

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/green_skill_classifier.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/green_skill_classifier.py
@@ -10,7 +10,6 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import classification_report
-from sklearn.metrics import precision_recall_fscore_support
 from sklearn.metrics.pairwise import cosine_similarity
 import spacy
 
@@ -23,7 +22,6 @@ from dap_prinz_green_jobs.getters.occupation_getters import (
 )
 
 from tqdm import tqdm
-import pickle
 from typing import List, Union, Tuple
 import joblib
 import s3fs

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/green_skill_classifier.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/green_skill_classifier.py
@@ -1,0 +1,431 @@
+"""
+Script to train and use a classifier to predict green or not-green from a skill text
+Will also output the closest green ESCO skill if green is predicted
+"""
+
+import pandas as pd
+import numpy as np
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import classification_report
+from sklearn.metrics import precision_recall_fscore_support
+from sklearn.metrics.pairwise import cosine_similarity
+import spacy
+
+from dap_prinz_green_jobs.utils.bert_vectorizer import get_embeddings
+from dap_prinz_green_jobs.getters.data_getters import load_s3_data, save_to_s3
+from dap_prinz_green_jobs.getters.skill_getters import get_green_skills_taxonomy
+from dap_prinz_green_jobs import BUCKET_NAME, logger
+from dap_prinz_green_jobs.getters.occupation_getters import (
+    load_onet_green_topics,
+)
+
+from tqdm import tqdm
+import pickle
+from typing import List, Union, Tuple
+import joblib
+import s3fs
+from datetime import datetime
+import os
+
+OJO_BUCKET_NAME = "open-jobs-lake"
+
+
+def find_green_topics(skill_ent: str, green_topics: list) -> list:
+    """
+    Find the green topics which are contained within a skill entity using exact matching
+    Args:
+        skill_ent: A skill entity
+        green_topics: A list of green topics
+    Returns:
+        list: A list of the green topics found in this skill entity (can be empty)
+    Example:
+        find_green_topics("We want someone with an interest in sustainability", ["Sustainability", "Green Energy"])
+        returns ["Sustainability"]
+    """
+    found_green_topics = []
+    for green_topic in green_topics:
+        # Basic cleaning
+        green_topic = green_topic.lower()
+        clean_skill_ent = skill_ent.lower()
+        clean_skill_ent = " ".join(clean_skill_ent.split())
+        if green_topic in clean_skill_ent:
+            found_green_topics.append(green_topic)
+    return found_green_topics
+
+
+def process_green_topic_data(nlp):
+    """
+    Function to load the ONET green topic data, clean it, add to it
+
+    Args:
+        nlp: Spacy model used to lemmatise the green topic
+
+    Returns:
+        list: The new processed list of ONET green topics
+    """
+
+    green_topics = load_onet_green_topics()
+
+    green_topics = green_topics["Topic"].unique()
+
+    # Lower case green topics, and lemmatised versions of them too
+    enhanced_green_topics = set()
+    for green_topic in green_topics:
+        green_topic = green_topic.lower()
+        enhanced_green_topics.add(green_topic)
+        sent = nlp(green_topic)
+        enhanced_green_topics.add(" ".join(word.lemma_ for word in sent))
+
+    # Manual additions from green topics which are more wordy and can be split up
+    enhanced_green_topics.add(
+        "environmental health"
+    )  # 'environmental health and safety (ehs)'
+    enhanced_green_topics.add(
+        "environmental safety"
+    )  # 'environmental health and safety (ehs)'
+    enhanced_green_topics.add(
+        "leadership in energy design"
+    )  # 'leadership in energy and environmental design ( leed )'
+    enhanced_green_topics.add(
+        "leadership in environmental design"
+    )  # 'leadership in energy and environmental design ( leed )'
+    enhanced_green_topics.add(
+        "solid waste management"
+    )  # 'solid waste management , treatment , and reduction'
+    enhanced_green_topics.add(
+        "solid waste treatment"
+    )  # 'solid waste management , treatment , and reduction'
+    enhanced_green_topics.add(
+        "solid waste reduction"
+    )  # 'solid waste management , treatment , and reduction'
+    enhanced_green_topics.add("urban planning")  # 'urban and regional planning'
+    enhanced_green_topics.add("regional planning")  # 'urban and regional planning'
+    enhanced_green_topics.add(
+        "wastewater management"
+    )  # 'wastewater management , treatment , and reduction'
+    enhanced_green_topics.add(
+        "wastewater treatment"
+    )  # 'wastewater management , treatment , and reduction'
+    enhanced_green_topics.add(
+        "wastewater reduction"
+    )  # 'wastewater management , treatment , and reduction'
+
+    enhanced_green_topics = list(enhanced_green_topics)
+
+    return enhanced_green_topics
+
+
+def get_closest_match(
+    skills_list_embeddings_dict: dict,
+    green_data_embeddings_dict: dict,
+    formatted_green_data: pd.DataFrame(),
+) -> dict:
+    """
+    Find the semantically closest matches for each skill in skills_list_embeddings_dict
+    using a green data set and their associated embeddings
+    Args:
+        skills_list_embeddings_dict: The skill to the skill embedding
+        green_data_embeddings_dict: The green data embeddings
+        formatted_green_data: Must have a "description" and a "id" column
+
+        Note: the key of green_data_embeddings_dict must be associated with the index of formatted_green_data
+        i.e. The embedding for formatted_green_data.iloc[4] is in green_data_embeddings_dict[4]
+
+    Returns:
+        dict: gives the skill to the green data match information (if any found)
+    """
+
+    similarities = cosine_similarity(
+        np.array(list(skills_list_embeddings_dict.values())),
+        np.array(list(green_data_embeddings_dict.values())),
+    )
+    # Top matches for skill chunk
+    top_green_skills = get_green_skill_matches(
+        extracted_skill_list=list(skills_list_embeddings_dict.keys()),
+        similarities=similarities,
+        green_skills_taxonomy=formatted_green_data,
+        skill_threshold=0,
+    )
+
+    return {sk[0]: sk[1] for sk in top_green_skills if sk[1]}
+
+
+def get_green_skill_matches(
+    extracted_skill_list: List[str],
+    similarities: np.array,
+    green_skills_taxonomy: pd.DataFrame(),
+    skill_threshold: float = 0.7,
+) -> List[Tuple[str, Tuple[str, int]]]:
+    """Get green skill matches for a list of extracted skills - use this
+            in extract_green_measures flow instead of get_green_skill_measures
+
+            NOTE: this is because speeds up skills mapping considerably
+            and because the esco green taxonomy is not hierarchical so we are simply
+            matching the extracted skills to the green taxonomy based on a minimum
+            threshold cosine similarity.
+
+    Args:
+            extracted_skill_list (List[str]): List of extracted skills
+
+    Returns:
+            List[Tuple[str, Tuple[str, int, int]]]: List of tuples with the extracted
+                            skill; the mapped green skill, a green skill id and the match similarity score
+    """
+    skill_top_green_skills = []
+    for skill_ix, skill in tqdm(enumerate(extracted_skill_list)):
+        top_skill_match = np.flip(np.sort(similarities[skill_ix]))[0:1]
+        if top_skill_match[0] > skill_threshold:
+            green_skill_ix = np.flip(np.argsort(similarities[skill_ix]))[0:1]
+            green_skill = green_skills_taxonomy.iloc[green_skill_ix].description.values[
+                0
+            ]
+            green_skill_id = green_skills_taxonomy.iloc[green_skill_ix].id.values[0]
+            skill_top_green_skills.append(
+                (skill, (green_skill, green_skill_id, top_skill_match[0]))
+            )
+        else:
+            skill_top_green_skills.append((skill, None))
+
+    return skill_top_green_skills
+
+
+class GreenSkillClassifier(object):
+    def __init__(self):
+        logger.info("Downloading ONET green topics")
+        nlp = spacy.load("en_core_web_sm")
+        self.enhanced_green_topics = process_green_topic_data(nlp)
+        # Format into a format needed for get_green_skill_matches()
+        self.formatted_green_topics = (
+            pd.DataFrame({"description": self.enhanced_green_topics})
+            .reset_index()
+            .rename(columns={"index": "id"})
+        )
+
+        logger.info("Embedding ONET green topics")
+        self.enhanced_green_topics_embeddings_dict = get_embeddings(
+            self.enhanced_green_topics
+        )
+
+    def load_training_data(
+        self,
+        training_data_path: str = "inputs/data/training_data/green_skill_training_data.csv",
+    ) -> pd.DataFrame:
+        """
+        Download the training data and clean it a little
+        """
+        all_data = load_s3_data(
+            BUCKET_NAME,
+            training_data_path,
+        )
+
+        all_data["green?"] = all_data["green?"].map(
+            {"TRUE": "green", "FALSE": "not_green"}
+        )
+        data = all_data[all_data["green?"].isin(["green", "not_green"])]
+
+        return data
+
+    def load_esco_data(self):
+        logger.info("Downloading ESCO green taxonomy embeddings")
+        self.taxonomy_skills_embeddings_dict = load_s3_data(
+            BUCKET_NAME,
+            "outputs/data/green_skill_lists/green_esco_embeddings_20230815.json",
+        )
+
+        logger.info("Downloading ESCO green taxonomy")
+        self.formatted_taxonomy = get_green_skills_taxonomy()
+
+    def transform(
+        self,
+        skill_entity_list: Union[str, List[str]],
+        skills_list_embeddings_dict: Union[None, list],
+    ):
+        """
+        Transform a list of skill entities into 3 numerical features;
+        1. The closest similarity score between the skill entity and a ESCO green skill
+        2. The closest similarity score between the skill entity and a ONET green topic
+        3. The number of ONET green topics exactly found in the skill entity text
+
+        Args:
+            skill_entity_list (str or list of strings): A skill entity text or a list of them
+            skills_list_embeddings_dict (None or list): The embeddings for the skill entity if they have already been calculated
+        Returns:
+            list: For every skill entity inputted, 3 numerical features are calculated and outputted in a list
+            dict: A dictionary of unique skill entities to which closest green ESCO skill they match to
+
+        """
+
+        if isinstance(skill_entity_list, str):
+            skill_entity_list = [skill_entity_list]
+
+        if not skills_list_embeddings_dict:
+            skills_list_embeddings_dict = get_embeddings(skill_entity_list)
+
+        # Get the similarity to the closest ESCO green skill
+        all_extracted_green_skills_dict = get_closest_match(
+            skills_list_embeddings_dict,
+            self.taxonomy_skills_embeddings_dict,
+            self.formatted_taxonomy,
+        )
+
+        # Get the similarity to the closest green topic
+        green_skills_green_topics_dict = get_closest_match(
+            skills_list_embeddings_dict,
+            self.enhanced_green_topics_embeddings_dict,
+            self.formatted_green_topics,
+        )
+
+        # Return esco_score, green_topic_score, num_topics for each skill in skill_entity_list
+
+        return [
+            [
+                all_extracted_green_skills_dict.get(skill_ent)[2],
+                green_skills_green_topics_dict.get(skill_ent)[2],
+                len(find_green_topics(skill_ent, self.enhanced_green_topics)),
+            ]
+            for skill_ent in skill_entity_list
+        ], all_extracted_green_skills_dict
+
+    def fit(self, X_train: Union[np.array, list], y_train: Union[np.array, list]):
+        """
+        Fit a random forest classifier to the training data
+        Args:
+            X_train: Training features
+            y_train: Test data
+
+        Returns:
+            sklearn.pipeline.Pipeline
+        """
+
+        self.model = make_pipeline(
+            StandardScaler(),
+            RandomForestClassifier(
+                n_estimators=500, random_state=42, class_weight="balanced"
+            ),
+        )
+
+        self.model = self.model.fit(X_train, y_train)
+        return self.model
+
+    def fit_transform(
+        self, skill_entity_list: list, y_train: Union[np.array, list]
+    ) -> list:
+        """
+        Fit a random forest classifier to skill entities
+        Args:
+            skill_entity_list: A list of skill entities
+            y_train: Test data
+
+        Returns:
+            The transformed feature data
+        """
+
+        skills_list_transform, _ = self.transform(skill_entity_list)
+
+        self.model = self.fit(skills_list_transform, y_train)
+
+        return skills_list_transform
+
+    def predict(
+        self,
+        skill_entity_list: Union[str, List[str]],
+        skills_list_embeddings_dict: Union[None, list],
+        output_match: bool = True,
+    ) -> list:
+        """
+        Predict "green" or "not_green" for a list of skill entities
+        output_match = True to output more information about the top ESCO green skill match
+
+        Args:
+            skill_entity_list: A skill entity or a list of skill entities
+            skills_list_embeddings_dict (None or list): The embeddings for the skill entity if they have already been calculated
+            output_match: Whether to output the top ESCO green skill match (True) or not (False)
+
+        Returns:
+            list: The predictions of whether the input skills are green or not
+
+        """
+
+        if isinstance(skill_entity_list, str):
+            skill_entity_list = [skill_entity_list]
+
+        skills_list_transform, all_extracted_green_skills_dict = self.transform(
+            skill_entity_list, skills_list_embeddings_dict=skills_list_embeddings_dict
+        )
+
+        class_pred = list(self.model.predict(skills_list_transform))
+        if output_match:
+            # ("green", 0.97, [top_esco_match, top_esco_match_id, top_esco_match_score])
+            class_pred_prob = list(
+                np.max(self.model.predict_proba(skills_list_transform), axis=1)
+            )
+            y_pred = list(
+                zip(
+                    class_pred,
+                    class_pred_prob,
+                    [
+                        all_extracted_green_skills_dict[skill_ent]
+                        for skill_ent in skill_entity_list
+                    ],
+                )
+            )
+        else:
+            y_pred = self.model.predict(skills_list_transform)
+
+        return y_pred
+
+    def evaluate(self, X_test, y_test):
+        y_preds = green_skills_classifier.predict(X_test["ent"].tolist())
+        self.results = classification_report(
+            y_test, [p[0] for p in y_preds], output_dict=True
+        )
+        return self.results
+
+    def save(self, output_file, results_dict=None):
+        logger.info(f"Saving the model to {output_file}")
+        fs = s3fs.S3FileSystem()
+
+        with fs.open(os.path.join(f"s3://{BUCKET_NAME}", output_file), "wb") as f:
+            joblib.dump(self.model, f)
+
+        if results_dict:
+            save_to_s3(
+                BUCKET_NAME,
+                results_dict,
+                output_file.split(".joblib")[0] + "_results.json",
+            )
+
+    def load(
+        self,
+        model_file="s3://prinz-green-jobs/outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib",
+    ):
+        logger.info(f"Loading the model from {model_file}")
+        fs = s3fs.S3FileSystem()
+
+        with fs.open(model_file, "rb") as f:
+            self.model = joblib.load(f)
+
+
+if __name__ == "__main__":
+    green_skills_classifier = GreenSkillClassifier()
+
+    data = green_skills_classifier.load_training_data()
+    green_skills_classifier.load_esco_data()
+    X_train, X_test, y_train, y_test = train_test_split(
+        data, data["green?"], test_size=0.25, random_state=42
+    )
+
+    _ = green_skills_classifier.fit_transform(X_train["ent"].tolist(), y_train)
+    green_skills_classifier.predict("A skill about sustainable development")
+
+    test_results = green_skills_classifier.evaluate(X_test, y_test)
+
+    date = datetime.now().strftime("%Y-%m-%d").replace("-", "")
+
+    output_file = (
+        f"outputs/models/green_skill_classifier/green_skill_classifier_{date}.joblib"
+    )
+    green_skills_classifier.save(output_file, results_dict=test_results)

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/map_skills_utils.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/map_skills_utils.py
@@ -1,0 +1,333 @@
+"""
+Utils to match skill embeddings to all of the ESCO taxonomy. This is a temporary measure since at the moment there
+is no functionality in ojd_daps_skills to take in already embedded skills and map them.
+
+As such, very little in this script is actually new code. It is mostly all copied from ojd_daps_skills, specifically,
+- ojd_daps_skills.pipeline.skill_ner_mapping.skill_ner_mapper.py
+- ojd_daps_skills.config.extract_skills_esco.yaml
+
+"""
+
+from ojd_daps_skills.pipeline.skill_ner_mapping.skill_ner_mapper_utils import (
+    get_top_comparisons,
+    get_most_common_code,
+)
+from dap_prinz_green_jobs.getters.data_getters import save_to_s3, load_s3_data
+
+import re
+import time
+import itertools
+from sklearn.metrics.pairwise import cosine_similarity
+import numpy as np
+import pandas as pd
+import os
+
+import ast
+
+
+def clean_string_list(string_list):
+    """
+    THIS IS THE SAME AS clean_string_list() IN skill_ner_mapper.py
+    """
+
+    if pd.notnull(string_list):
+        if isinstance(string_list, str):
+            return ast.literal_eval(string_list)
+        else:
+            return string_list
+    else:
+        return None
+
+
+def final_prediction(
+    skills_to_taxonomy,
+    hier_name_mapper,
+    match_thresholds_dict,
+    num_hier_levels,
+):
+    """
+    THIS IS THE SAME AS final_prediction() IN skill_ner_mapper.py, just with some self. removed
+
+    Using all the information in skill_mapper_list get a final ESCO match (if any)
+    for each ojo skill, based off a set of rules.
+    """
+
+    rank_matches = []
+    for match_id, v in enumerate(skills_to_taxonomy):
+        match_num = 0
+
+        # Try to find a close similarity skill
+        skill_info = {
+            "ojo_skill": v["ojo_ner_skill"],
+            "match_id": v["ojo_skill_id"],
+        }
+        match_hier_info = {}
+        top_skill, top_skill_code, top_sim_score = v["top_tax_skills"][0]
+        if top_sim_score >= match_thresholds_dict["skill_match_thresh"]:
+            skill_info.update({"match " + str(match_num): top_skill})
+            match_hier_info[match_num] = {
+                "match_code": top_skill_code,
+                "type": "skill",
+                "value": top_sim_score,
+            }
+            match_num += 1
+
+        # Go through hierarchy levels from most granular to least
+        # and try to find a close match first in the most common level then in
+        # the level name with the closest similarity
+        for n in reversed(range(num_hier_levels)):
+            # Look at level n most common
+            type_name = "most_common_level_" + str(n)
+            if "high_tax_skills" in v.keys():
+                if (type_name in v["high_tax_skills"]) and (
+                    n in match_thresholds_dict["max_share"]
+                ):
+                    c0 = v["high_tax_skills"][type_name]
+                    if (c0[1]) and (c0[1] >= match_thresholds_dict["max_share"][n]):
+                        match_name = hier_name_mapper.get(c0[0], c0[0])
+                        skill_info.update({"match " + str(match_num): match_name})
+                        match_hier_info[match_num] = {
+                            "match_code": c0[0],
+                            "type": type_name,
+                            "value": c0[1],
+                        }
+                        match_num += 1
+
+            # Look at level n closest similarity
+            type_name = "top_level_" + str(n) + "_tax_level"
+            if (type_name in v) and (n in match_thresholds_dict["top_tax_skills"]):
+                c1 = v[type_name]
+                if c1[2] >= match_thresholds_dict["top_tax_skills"][n]:
+                    skill_info.update({"match " + str(match_num): c1[0]})
+                    match_hier_info[match_num] = {
+                        "match_code": c1[1],
+                        "type": type_name,
+                        "value": c1[2],
+                    }
+                    match_num += 1
+
+        skill_info.update({"match_info": match_hier_info})
+        rank_matches.append(skill_info)
+
+    # Just pull out the top matches for each ojo skill
+    final_match = []
+    for rank_match in rank_matches:
+        if "match 0" in rank_match.keys():
+            final_match.append(
+                {
+                    "ojo_skill": rank_match["ojo_skill"],
+                    "ojo_job_skill_hash": rank_match["match_id"],
+                    "match_skill": rank_match["match 0"],
+                    "match_score": rank_match["match_info"][0]["value"],
+                    "match_type": rank_match["match_info"][0]["type"],
+                    "match_id": rank_match["match_info"][0]["match_code"],
+                }
+            )
+
+    return final_match
+
+
+def map_esco_skills(
+    skill_ents: list, all_extracted_skills_embeddings_dict: dict
+) -> dict:
+    """
+    Map skills to the most semantically similar ESCO skill
+
+    This function is very similar to what is in skill_ner_mapper.py in the ojd_daps_skills package.
+
+    Args:
+        skill_ents: a list of skills
+        all_extracted_skills_embeddings_dict: the associated embeddings for the skills in skill_ents
+
+    Returns:
+        dict: The skill mapped to an ESCO skill (if it does map)
+    """
+
+    # -----------------------------------------------------------------------
+    # THE FOLLOWING IS NEW, BUT ALL STILL COPIED from the config file and parts of extract_skills.py
+    # -----------------------------------------------------------------------
+
+    skill_type_col = "type"
+    skill_type_dict = {
+        "skill_types": ["preferredLabel", "altLabels"],
+        "hier_types": ["level_2", "level_3"],
+    }
+    skill_types = skill_type_dict.get("skill_types", [])
+    skill_hashes_filtered = dict(zip(range(len(skill_ents)), skill_ents))
+    skill_name_col = "description"
+    skill_id_col = "id"
+    skill_hier_info_col = "hierarchy_levels"
+    num_hier_levels = 4
+    match_thresholds_dict = {
+        "skill_match_thresh": 0.7,
+        "top_tax_skills": {1: 0.5, 2: 0.5, 3: 0.5},
+        "max_share": {1: 0, 2: 0.2, 3: 0.2},
+    }
+
+    taxonomy_skills = load_s3_data(
+        "open-jobs-lake",
+        "escoe_extension/outputs/data/skill_ner_mapping/esco_data_formatted.csv",
+    )
+
+    taxonomy_skills = taxonomy_skills[
+        taxonomy_skills[skill_name_col].notna()
+    ].reset_index(drop=True)
+    taxonomy_skills[skill_hier_info_col] = taxonomy_skills[skill_hier_info_col].apply(
+        clean_string_list
+    )
+
+    saved_taxonomy_embeds = load_s3_data(
+        "open-jobs-lake",
+        "escoe_extension/outputs/data/skill_ner_mapping/esco_embeddings.json",
+    )
+
+    taxonomy_skills_embeddings_dict = {
+        int(embed_indx): np.array(embedding)
+        for embed_indx, embedding in saved_taxonomy_embeds.items()
+    }
+
+    clean_ojo_skill_embeddings = list(all_extracted_skills_embeddings_dict.values())
+
+    # -----------------------------------------------------------------------
+    # THE FOLLOWING IS COPIED FROM `skill_ner_mapper.py` (with self. removed)
+    # -----------------------------------------------------------------------
+
+    tax_skills_ix = taxonomy_skills[
+        taxonomy_skills[skill_type_col].isin(skill_types)
+    ].index
+
+    (skill_top_sim_indxs, skill_top_sim_scores) = get_top_comparisons(
+        clean_ojo_skill_embeddings,
+        [taxonomy_skills_embeddings_dict[i] for i in tax_skills_ix],
+        match_sim_thresh=0.5,
+    )
+
+    # Find the closest matches to the hierarchy levels information
+    hier_types = {i: v for i, v in enumerate(skill_type_dict.get("hier_types", []))}
+    hier_types_top_sims = {}
+    for hier_type_num, hier_type in hier_types.items():
+        taxonomy_skills_ix = taxonomy_skills[
+            taxonomy_skills[skill_type_col] == hier_type
+        ].index
+        top_sim_indxs, top_sim_scores = get_top_comparisons(
+            clean_ojo_skill_embeddings,
+            [taxonomy_skills_embeddings_dict[i] for i in taxonomy_skills_ix],
+        )
+        hier_types_top_sims[hier_type_num] = {
+            "top_sim_indxs": top_sim_indxs,
+            "top_sim_scores": top_sim_scores,
+            "taxonomy_skills_ix": taxonomy_skills_ix,
+        }
+
+    # Output the top matches (using the different metrics) for each OJO skill
+    # Need to match indexes back correctly (hence all the ix variables)
+    skill_mapper_list = []
+    for i, (match_i, match_text) in enumerate(skill_hashes_filtered.items()):
+        # Top highest matches (any threshold)
+        match_results = {
+            "ojo_skill_id": match_i,
+            "ojo_ner_skill": match_text,
+            "top_tax_skills": list(
+                zip(
+                    [
+                        taxonomy_skills.iloc[tax_skills_ix[top_ix]][skill_name_col]
+                        for top_ix in skill_top_sim_indxs[i]
+                    ],
+                    [
+                        taxonomy_skills.iloc[tax_skills_ix[top_ix]][skill_id_col]
+                        for top_ix in skill_top_sim_indxs[i]
+                    ],
+                    skill_top_sim_scores[i],
+                )
+            ),
+        }
+        # Using the top matches, find the most common codes for each level of the
+        # hierarchy (if hierarchy details are given), weighted by their similarity score
+        if skill_hier_info_col:
+            high_hier_codes = []
+            for sim_ix, sim_score in zip(
+                skill_top_sim_indxs[i], skill_top_sim_scores[i]
+            ):
+                tax_info = taxonomy_skills.iloc[tax_skills_ix[sim_ix]]
+                if tax_info[skill_hier_info_col]:
+                    hier_levels = tax_info[skill_hier_info_col]
+                    for hier_level in hier_levels:
+                        high_hier_codes += [hier_level] * round(sim_score * 10)
+            high_tax_skills_results = {}
+            for hier_level in range(num_hier_levels):
+                high_tax_skills_results[
+                    "most_common_level_" + str(hier_level)
+                ] = get_most_common_code(high_hier_codes, hier_level)
+            if high_tax_skills_results:
+                match_results["high_tax_skills"] = high_tax_skills_results
+        # Now get the top matches using the hierarchy descriptions (if hier_types isnt empty)
+        for hier_type_num, hier_type in hier_types.items():
+            hier_sims_info = hier_types_top_sims[hier_type_num]
+            taxonomy_skills_ix = hier_sims_info["taxonomy_skills_ix"]
+            tax_info = taxonomy_skills.iloc[
+                taxonomy_skills_ix[hier_sims_info["top_sim_indxs"][i][0]]
+            ]
+            match_results["top_" + hier_type + "_tax_level"] = (
+                tax_info[skill_name_col],
+                tax_info[skill_id_col],
+                hier_sims_info["top_sim_scores"][i][0],
+            )
+        skill_mapper_list.append(match_results)
+
+    # -----------------------------------------------------------------------
+    # THE FOLLOWING IS NEW
+    # -----------------------------------------------------------------------
+
+    hier_name_mapper = load_s3_data(
+        "open-jobs-lake",
+        "escoe_extension/outputs/data/skill_ner_mapping/esco_hier_mapper.json",
+    )
+
+    skill_matches = final_prediction(
+        skill_mapper_list,
+        hier_name_mapper,
+        match_thresholds_dict,
+        num_hier_levels,
+    )
+
+    # Hard coded skill matches
+    hard_coded_skills = load_s3_data(
+        "open-jobs-lake",
+        "escoe_extension/outputs/data/skill_ner_mapping/hardcoded_ojo_esco_lookup.json",
+    )
+    hard_coded_skills_dict = {}
+    for hard_coded_skill in hard_coded_skills.values():
+        hard_coded_skills_dict[hard_coded_skill["ojo_skill"]] = (
+            hard_coded_skill["match_skill"],
+            hard_coded_skill["match_id"],
+            1,
+        )
+
+    # Create dict in form {skill: (esco_skill_name, esco_skill_id, sim_score)}
+    all_extracted_skills_dict = {}
+    for skill_match_info in skill_matches:
+        skill = skill_match_info["ojo_skill"]
+        if skill in hard_coded_skills_dict:
+            all_extracted_skills_dict[skill] = hard_coded_skills_dict[skill]
+        else:
+            all_extracted_skills_dict[skill] = (
+                skill_match_info["match_skill"],
+                skill_match_info["match_id"],
+                round(skill_match_info["match_score"], 3),
+                skill_match_info["match_type"],
+            )
+
+    return all_extracted_skills_dict
+
+
+# if __name__ == '__main__':
+#     skill_ents = ['attention to detail', 'communication skills', 'Excel', 'communication', 'organisational skills', 'Word', 'somethingweirdthatwontbematched']
+
+#     from dap_prinz_green_jobs.utils.bert_vectorizer import get_embeddings
+
+#     all_extracted_skills_embeddings_dict = get_embeddings(skill_ents)
+
+#     all_extracted_skills_dict = map_esco_skills(skill_ents, all_extracted_skills_embeddings_dict)
+
+#     # 'attention to detail': ('attend to detail', '83e6510b-ffeb-4aec-959c-4265fd0ff7b7', 0.761, 'skill'),
+#     # 'communication skills': ('communication', '15d76317-c71a-4fa2-aadc-2ecc34e627b7', 1)

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/skill_measures_utils.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/skill_measures_utils.py
@@ -58,7 +58,11 @@ def split_up_skill_entities(
 
 
 class SkillMeasures(object):
-    def __init__(self, config_name="extract_green_skills_esco"):
+    def __init__(
+        self,
+        config_name="extract_green_skills_esco",
+        green_skills_classifier_model_file="outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib",
+    ):
         self.config = get_yaml_config(
             PROJECT_DIR / f"dap_prinz_green_jobs/config/{config_name}.yaml"
         )
@@ -67,6 +71,9 @@ class SkillMeasures(object):
         ]
 
         self.formatted_taxonomy_path = self.config["taxonomy_path"]
+        self.green_skills_classifier_model_file = os.path.join(
+            "s3://", BUCKET_NAME, green_skills_classifier_model_file
+        )
 
     def initiate_extract_skills(self, local=True, verbose=True):
         """
@@ -262,9 +269,7 @@ class SkillMeasures(object):
         )
         green_skills_classifier.formatted_taxonomy = self.formatted_taxonomy
 
-        green_skills_classifier.load(
-            model_file="s3://prinz-green-jobs/outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib"
-        )
+        green_skills_classifier.load(model_file=self.green_skills_classifier_model_file)
 
         pred_green_skill = green_skills_classifier.predict(
             skill_ents, skills_list_embeddings_dict=all_extracted_skills_embeddings_dict

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/skill_measures_utils.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/skill_measures_utils.py
@@ -64,7 +64,7 @@ class SkillMeasures(object):
     def __init__(
         self,
         config_name="extract_green_skills_esco",
-        green_skills_classifier_model_file="outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib",
+        green_skills_classifier_model_file_name="outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib",
     ):
         self.config = get_yaml_config(
             PROJECT_DIR / f"dap_prinz_green_jobs/config/{config_name}.yaml"
@@ -74,8 +74,8 @@ class SkillMeasures(object):
         ]
 
         self.formatted_taxonomy_path = self.config["taxonomy_path"]
-        self.green_skills_classifier_model_file = os.path.join(
-            "s3://", BUCKET_NAME, green_skills_classifier_model_file
+        self.green_skills_classifier_model_file_name = os.path.join(
+            "s3://", BUCKET_NAME, green_skills_classifier_model_file_name
         )
 
     def initiate_extract_skills(self, local=True, verbose=True):
@@ -299,7 +299,9 @@ class SkillMeasures(object):
         )
         green_skills_classifier.formatted_taxonomy = self.formatted_taxonomy
 
-        green_skills_classifier.load(model_file=self.green_skills_classifier_model_file)
+        green_skills_classifier.load(
+            model_file=self.green_skills_classifier_model_file_name
+        )
 
         pred_green_skill = green_skills_classifier.predict(
             skill_ents, skills_list_embeddings_dict=all_extracted_skills_embeddings_dict

--- a/dap_prinz_green_jobs/pipeline/ojo_application/extract_green_measures.py
+++ b/dap_prinz_green_jobs/pipeline/ojo_application/extract_green_measures.py
@@ -13,21 +13,17 @@ In production, this script should take about ~15 minutes to run now
 """
 from dap_prinz_green_jobs.pipeline.green_measures.green_measures import GreenMeasures
 import dap_prinz_green_jobs.pipeline.green_measures.skills.skill_measures_utils as sm
-
 from dap_prinz_green_jobs.getters.ojo_getters import (
     get_mixed_ojo_job_title_sample,
     get_mixed_ojo_sample,
 )
-
 from dap_prinz_green_jobs import logger
 from dap_prinz_green_jobs.getters.data_getters import save_to_s3
 from dap_prinz_green_jobs import BUCKET_NAME
 
 import pandas as pd
+
 from argparse import ArgumentParser
-from tqdm import tqdm
-from sklearn.metrics.pairwise import cosine_similarity
-import numpy as np
 from datetime import datetime as date
 
 if __name__ == "__main__":

--- a/dap_prinz_green_jobs/pipeline/ojo_application/extract_green_measures.py
+++ b/dap_prinz_green_jobs/pipeline/ojo_application/extract_green_measures.py
@@ -32,11 +32,16 @@ if __name__ == "__main__":
     parser.add_argument("--config_name", default="base", type=str)
 
     args = parser.parse_args()
+    production = args.production
 
     # instantiate GreenMeasures class here
-    gm = GreenMeasures(config_name=args.config_name)
-
-    production = args.production
+    if production:
+        gm = GreenMeasures(config_name=args.config_name)
+    else:
+        gm = GreenMeasures(
+            config_name=args.config_name,
+            skills_output_folder="outputs/data/green_skill_lists/test",
+        )
 
     # load and reformat relevant data
     logger.info("loading and reformatting datasets...")

--- a/dap_prinz_green_jobs/tests/test_skill_measures.py
+++ b/dap_prinz_green_jobs/tests/test_skill_measures.py
@@ -1,0 +1,86 @@
+import pytest
+
+from dap_prinz_green_jobs.pipeline.green_measures.skills.skill_measures_utils import (
+    SkillMeasures,
+    window_split,
+    split_up_skill_entities,
+)
+
+
+def test_split_up_skill_entities():
+    assert len(split_up_skill_entities(" ")) == 0
+    assert (
+        len(
+            split_up_skill_entities(
+                "small entity", max_entity_size=10, window_overlap=5
+            )
+        )
+        == 1
+    )
+
+    entity = "word1 word2 word3 word4 word5 word6"
+    max_entity_size = 3
+    window_overlap = 2
+    split_result = split_up_skill_entities(
+        entity, max_entity_size=max_entity_size, window_overlap=window_overlap
+    )
+
+    assert len(split_result) == 4
+    assert len(split_result[0].split()) == max_entity_size
+    assert split_result[0] == "word1 word2 word3"
+    assert split_result[1] == "word2 word3 word4"
+
+    entity = "word1 word2; word3 word4; word5 word6"
+    max_entity_size = 3
+    window_overlap = 2
+    split_result = split_up_skill_entities(
+        entity, max_entity_size=max_entity_size, window_overlap=window_overlap
+    )
+
+    assert len(split_result) == 3
+
+
+def test_skills_measures():
+    sm = SkillMeasures(config_name="extract_green_skills_esco")
+
+    ents_per_job = {
+        "123": [(["communication"], "SKILL"), (["Excel"], "SKILL")],
+        "456": [(["Heat pump installation"], "SKILL")],
+        "789": [],
+        "abc": [
+            (
+                [
+                    "Heat pump installation",
+                    "installation and boiler",
+                    "boiler upgrade skills",
+                ],
+                "MULTISKILL",
+            )
+        ],
+        "def": [(["Skill not found in all_extracted_green_skills_dict"], "SKILL")],
+    }
+    all_extracted_green_skills_dict = {
+        "communication": ["not-green", 0.9, []],
+        "Excel": ["not-green", 0.95, []],
+        "verbal communication": ["not-green", 0.85, []],
+        "Heat pump installation": ["green", 0.9, []],
+        "installation and boiler": ["not-green", 0.65, []],
+        "boiler upgrade skills": ["not-green", 0.85, []],
+    }
+    job_benefits_dict = {"123": [], "456": ["pension"]}
+
+    prop_green_skills = sm.calculate_measures(
+        ents_per_job,
+        all_extracted_green_skills_dict,
+        job_benefits_dict,
+    )
+
+    assert set(prop_green_skills.keys()) == set(ents_per_job.keys())
+    assert prop_green_skills["789"]["PROP_GREEN"] == 0
+    assert prop_green_skills["789"]["ENTS"] == None
+    assert (
+        prop_green_skills["abc"]["PROP_GREEN"]
+        == len(prop_green_skills["abc"]["GREEN_ENTS"])
+        / prop_green_skills["abc"]["NUM_SPLIT_ENTS"]
+    )
+    assert prop_green_skills["456"]["BENEFITS"] == ["pension"]

--- a/dap_prinz_green_jobs/utils/bert_vectorizer.py
+++ b/dap_prinz_green_jobs/utils/bert_vectorizer.py
@@ -1,7 +1,39 @@
 from sentence_transformers import SentenceTransformer
-import time
 from ojd_daps_skills import logger
+import numpy as np
+
+from dap_prinz_green_jobs.utils.processing import list_chunks
+
+import time
 import logging
+from tqdm import tqdm
+
+
+def get_embeddings(
+    sent_list: list, chunk_size: int = 1000, id_list: list = None
+) -> dict:
+    """
+    Embed a list of sentences in chunks
+    Args:
+        sent_list: A list of sentences
+        chunk_size: The number of sentences to embed at a time
+        id_list: The keys you want in the output dictionary, if not given then the sent_list values will be given
+    Returns:
+        dict: The sentence (key) and the embedding (value)
+    """
+
+    bert_model = BertVectorizer(verbose=True, multi_process=True).fit()
+
+    embeddings = []
+    for batch_texts in tqdm(list_chunks(sent_list, chunk_size)):
+        embeddings.append(bert_model.transform(batch_texts))
+    embeddings = np.concatenate(embeddings)
+
+    if not id_list:
+        id_list = sent_list
+
+    # create dict
+    return dict(zip(id_list, embeddings))
 
 
 class BertVectorizer:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,16 @@
 metaflow==2.8.0
 s3fs==2022.5.0
 boto3==1.21.21
-numpy==1.23.4
-pandas==1.5.1
+numpy==1.24.4
+pandas==1.3.5
 tqdm==4.64.0
-scikit-learn==0.23.2
+scikit-learn==1.3.1
 openpyxl
-ojd-daps-skills
+ojd-daps-skills @ git+https://github.com/nestauk/ojd_daps_skills.git@201_update_dependencies
 pyarrow==10.0.0
 altair
 umap
 vega
 plac
+en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.4.1/en_core_web_sm-3.4.1.tar.gz
+typing_extensions<4.6.0


### PR DESCRIPTION
---

# Description

Improves the way we map skills to ESCO green skills by training a classifier.

- Adds a green skills classifier [green_skill_classifier.py](https://github.com/nestauk/dap_prinz_green_jobs/pull/67/files#diff-5b1eef6538de374e362539cc95b1697a5a54742f4027da22d0d1924edbb63ded)
- Creates a new function `.get_measures` in SkillMeasures which inputs the job advert. Before this wasn't actually in a function, and there were 2 instances of repeating code to do it.
- Changes to [/skill_measures_utils.py](https://github.com/nestauk/dap_prinz_green_jobs/pull/67/files#diff-2698988567d6467a6a8bdacb5371d35dc1de9a40fe6c86519e13f0108b3eab39) to include the green skill classifier
- Updates README
- Adds a util function [map_skills_utils.py](https://github.com/nestauk/dap_prinz_green_jobs/pull/67/files#diff-482143cae871314d57fc55468f4bd1b25300a0e4c8ae6b2c223ef8163a47c907) to map the skills to all of ESCO (not just green ESCO). This is comprised of code copied from ojd_daps_skills (I've tried to make it clear what is copied). So doesn't really need reviewing. Its a temporary fix, but ideally in the future we'd change ojd_daps_skills to have this functionality - unless it turns out we never use the skills mapped to all of ESCO
- skill measures test [test_skill_measures.py](https://github.com/nestauk/dap_prinz_green_jobs/pull/67/files#diff-133a94cdcb82daaa411ff73396cd4e4eea7761d6cf56fe2161c74879e7b5e04b)
- New get_embeddings function in [bert_vectorizer.py](https://github.com/nestauk/dap_prinz_green_jobs/pull/67/files#diff-5f769ae27b765d9eb7317ad265da6c7d55606be3815cc3afcff584dc6d3d70f4) - just because this code kept being repeated

Fixes #45 #27  #10 (since it uses ONET green topics in the classifier)

# Instructions for Reviewer

In order to test the code in this PR you need to ...

See if the tests work:
```
pytest
```

Check out the new green skill classifier:
```
from dap_prinz_green_jobs.pipeline.green_measures.skills.green_skill_classifier import GreenSkillClassifier

green_skills_classifier = GreenSkillClassifier()
green_skills_classifier.load_esco_data()
green_skills_classifier.load(
    model_file="s3://prinz-green-jobs/outputs/models/green_skill_classifier/green_skill_classifier_20230906.joblib"
)

pred_green_skill = green_skills_classifier.predict(
    ["Excel skills", "Heat pump installation skills"]
)

>>> [('not_green', 1.0, ('carry out sample analysis', '82423b5c-486f-42e7-b00e-7358757a8de5', 0.2772792296638087)), ('green', 0.7191159533073931, ('heat pump installation', '00735755-adc6-4ea0-b034-b8caff339c9f', 0.9072619656040537))]
```

Check out the new green skills measures

```
from dap_prinz_green_jobs.pipeline.green_measures.skills.skill_measures_utils import (
    SkillMeasures,
)
sm = SkillMeasures(config_name="extract_green_skills_esco")
sm.initiate_extract_skills(local=False, verbose=True)

job_adverts = [
    {"id": 1, "job_text": "This job requires communication and Excel skills. We want someone with experience in sustainability. Heat pump installation skills would be useful. We have a pension scheme benefit."},
    {"id": 55, "job_text": "This job contains no skills."},
    {"id": 3, "job_text": "This job contains Excel skills."},
    {"id": 8, "job_text": "This job contains a really long sentence. Promote good practice of material sustainability (reuse and or recycle) initiatives to reduce waste and save costs."},
    ]

# We will load the green taxonomy embeddings from S3 since they have already been calculated
taxonomy_skills_embeddings_dict = sm.get_green_taxonomy_embeddings(
    output_path="outputs/data/green_skill_lists/green_esco_embeddings_20230815.json", load=True)

prop_green_skills = sm.get_measures(job_adverts)
```
# Next:

After applying these changes to the mixed ojo sample, the new results for these green skills will be in `outputs/data/ojo_application/extracted_green_measures/20230912/ojo_sample_skills_green_measures_production_False_base.json`

I intend to rerun some of the analysis using these/quality check the most common green skills etc.


# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained this PR above
- [ ] I have requested a code review
