### PR TITLE
Fix tests for github action tests

### DIFF
--- a/dap_prinz_green_jobs/pipeline/green_measures/industries/sic_mapper/sic_mapper.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/industries/sic_mapper/sic_mapper.py
@@ -213,6 +213,8 @@ class SicMapper(object):
         # based on evaluation, we have hard coded for some companies
         self.hard_coded_sics = su.hard_coded_sics
 
+        self.sic_section_dict = su.get_sic_to_section()
+
     def preprocess_job_adverts(
         self, job_adverts: List[Dict[str, str]]
     ) -> List[Dict[str, str]]:
@@ -393,7 +395,8 @@ class SicMapper(object):
 
             # find the majority sic at sic levels 2-,3- and 4-
             top_candidate_sics = [
-                su.find_majority_sic(top_sics, lvl) for lvl in self.sic_levels
+                su.find_majority_sic(top_sics, lvl, self.sic_section_dict)
+                for lvl in self.sic_levels
             ]
             all_maj_sics = {k: v for d in top_candidate_sics for k, v in d.items()}
             sic_method = "majority SIC"

--- a/dap_prinz_green_jobs/pipeline/green_measures/industries/sic_mapper/sic_mapper_utils.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/industries/sic_mapper/sic_mapper_utils.py
@@ -14,13 +14,6 @@ hard_coded_sics = {
     "SaintGobain": "231",
 }
 
-sic_data = load_sic()
-sic_to_section = {
-    str(k).strip(): v.strip()
-    for k, v in dict(
-        zip(sic_data["Most disaggregated level"], sic_data["SECTION"])
-    ).items()
-}
 # Found using the most common words in CH data
 company_stopwords = set(
     [
@@ -85,6 +78,17 @@ sentence_replacement_rules = {
     r"[^\w\s,.]": "",  # Remove punctuation that isn't a comma
     r"\s+": " ",  # Convert multiple spaces to single spaces
 }
+
+
+def get_sic_to_section():
+    sic_data = load_sic()
+    sic_to_section = {
+        str(k).strip(): v.strip()
+        for k, v in dict(
+            zip(sic_data["Most disaggregated level"], sic_data["SECTION"])
+        ).items()
+    }
+    return sic_to_section
 
 
 def clean_sic(sic_name: str) -> str:
@@ -194,7 +198,7 @@ def convert_indx_to_sic(
 
 
 def add_sic_section(
-    sic_codes: List[str], sic_section_dict: Dict[str, str] = sic_to_section
+    sic_codes: List[str], sic_section_dict: Dict[str, str]
 ) -> List[str]:
     """Adds the SIC section to the SIC code.
 
@@ -222,7 +226,9 @@ def add_sic_section(
     return sic_codes
 
 
-def find_majority_sic(input_list: List[str], length: int) -> Dict[str, int]:
+def find_majority_sic(
+    input_list: List[str], length: int, sic_section_dict: Dict[str, str]
+) -> Dict[str, int]:
     """Finds the majority SIC code.
 
     Args:
@@ -235,7 +241,7 @@ def find_majority_sic(input_list: List[str], length: int) -> Dict[str, int]:
     if not input_list or length <= 0:
         return {}
 
-    input_sics_sections = add_sic_section(input_list)
+    input_sics_sections = add_sic_section(input_list, sic_section_dict)
 
     subelement_count = {}
 

--- a/dap_prinz_green_jobs/pipeline/green_measures/skills/skill_measures_utils.py
+++ b/dap_prinz_green_jobs/pipeline/green_measures/skills/skill_measures_utils.py
@@ -65,6 +65,7 @@ class SkillMeasures(object):
         self,
         config_name="extract_green_skills_esco",
         green_skills_classifier_model_file_name="outputs/models/green_skill_classifier/green_skill_classifier_20231129.joblib",
+        initialise_gs_classifier=True,
     ):
         self.config = get_yaml_config(
             PROJECT_DIR / f"dap_prinz_green_jobs/config/{config_name}.yaml"
@@ -78,7 +79,8 @@ class SkillMeasures(object):
             "s3://", BUCKET_NAME, green_skills_classifier_model_file_name
         )
 
-        self.green_skills_classifier = GreenSkillClassifier()
+        if initialise_gs_classifier:
+            self.green_skills_classifier = GreenSkillClassifier()
 
     def initiate_extract_skills(self, local=True, verbose=True):
         """

--- a/dap_prinz_green_jobs/tests/test_skill_measures.py
+++ b/dap_prinz_green_jobs/tests/test_skill_measures.py
@@ -41,7 +41,9 @@ def test_split_up_skill_entities():
 
 
 def test_skills_measures():
-    sm = SkillMeasures(config_name="extract_green_skills_esco")
+    sm = SkillMeasures(
+        config_name="extract_green_skills_esco", initialise_gs_classifier=False
+    )
 
     ents_per_job = {
         "123": [(["communication"], "SKILL"), (["Excel"], "SKILL")],


### PR DESCRIPTION
Put the loading of the sic data into a function of `sic_mapper_utils` so that it doesn't error when we run the github actions tests.

```
from dap_prinz_green_jobs.pipeline.green_measures.industries.sic_mapper.sic_mapper_utils import (
    clean_sic,
)
```

was failing in `test_industry_measures.py`

Similarly with the test_skills_measures.py
---

# Description

Please include a summary of the changes.

Fixes # (issue)

# Instructions for Reviewer

In order to test the code in this PR you need to ...

Please pay special attention to ...

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained this PR above
- [ ] I have requested a code review
